### PR TITLE
basic us supreme court

### DIFF
--- a/citation.js
+++ b/citation.js
@@ -312,6 +312,8 @@ if (typeof(require) !== "undefined") {
   Citation.types.dc_law = require("./citations/dc_law");
   Citation.types.stat = require("./citations/stat");
 
+  Citation.types.supreme_court = require("./citations/supreme_court");
+
   Citation.filters.lines = require("./filters/lines");
 }
 

--- a/citations/supreme_court.js
+++ b/citations/supreme_court.js
@@ -1,0 +1,43 @@
+module.exports = {
+  type: "regex",
+
+  id: function(cite) {
+    return ["supreme_court", cite.volume, cite.page, cite.year].join("/");
+  },
+
+  patterns: [
+    // 533 U.S. 218 (2001)
+    {
+      regex: 
+        '(\\d+)' +         // volume
+        ' U\\.S\\. ' +     // U.S.
+        '(\\d+)' +         // page
+        ' \\((\\d+)\\)',   // year
+      fields: [
+        'volume',
+        'page',
+        'year'
+      ],
+      processor: function(match) {
+        return {
+          volume: match.volume,
+          page: match.page,
+          year: match.year
+        };
+      }
+    }
+    // TODO: United States v. Mead Corp., 533 U.S. 218 (2001)
+  ]
+};
+
+
+/*
+Goal:
+
+parties
+volume
+reporter (U.S. or U. S.)
+begin page
+cite page (optional)
+year
+*/

--- a/test/supreme_court.js
+++ b/test/supreme_court.js
@@ -1,0 +1,35 @@
+/*
+  Tests for extracting US Supreme Court citations.
+  Each test should link to a real world circumstance where possible.
+
+  In-progress:
+  - Currently does not capture the parties
+  - I'm not sure if this should be a separate file, or part of a larger judicial extractor.
+    - For example, maybe this should have a `reporter` field, and not specify that it's from the US Sup. Ct.
+    - Instead, the reporter tells you which court.
+*/
+
+var Citation = require('../citation');
+
+exports["Basic pattern, no parties"] = function(test) {
+  var text = "United States v. Mead Corp., 533 U.S. 218 (2001)";
+
+  var found = Citation.find(text, {types: "supreme_court"});
+  var citation = found.citations[0];
+
+  test.equal(citation.supreme_court.volume, '533');
+  test.equal(citation.supreme_court.page, '218');
+  test.equal(citation.supreme_court.year, '2001');
+  test.equal(citation.supreme_court.id, "supreme_court/533/218/2001");
+
+  test.done();
+};
+
+/*
+parties
+volume
+reporter (U.S. or U. S.)
+begin page
+cite page (optional)
+year
+*/


### PR DESCRIPTION
In-progress, so don't merge unless we really want this as is:

- Currently does not capture the parties.
- I'm not sure if this should be a separate file, or part of a larger judicial extractor. For example, maybe this should have a `reporter` field, and not specify that it's from the Supreme Court. Instead, the reporter tells you which court.

e.g., which is better:

```
// option1
{
  reporter: 'U.S',
  volume: '533',
  page: '218',
  year: '2001',
  id: 'judicial/U.S./533/218/2001'
}
```
or

```
// option2
{
  volume: '533',
  page: '218',
  year: '2001',
  id: 'supreme_court/533/218/2001'
}
```

`option1` is better in that it's more namespacey and prevents re-inventing the reporter name wheel developed by smart lawyers. On the other hand, there currently is no namespace for branch of government or type of citation (e.g. we do not have `legislative`, `regulatory`, `judicial`, or `executive`). Of course, this might be a good thing, as those categories can by up fro debate. What is not up for debate, is that a citation refers to *something* from the Supreme Court. Obviously a Supreme Court citation is judicial, but creating these categories will imply that that items not placed in judicial are non-judicial, or regulatory items are not legislative, etc.