### PR TITLE
Updates for DC Stat and to add extra space for US reporter

### DIFF
--- a/citation.js
+++ b/citation.js
@@ -363,6 +363,7 @@ if (typeof(require) !== "undefined") {
   Citation.types.dc_code = require("./citations/dc_code");
   Citation.types.dc_register = require("./citations/dc_register");
   Citation.types.dc_law = require("./citations/dc_law");
+  Citation.types.dc_stat = require("./citations/dc_stat");
   Citation.types.stat = require("./citations/stat");
   Citation.types.reporter = require("./citations/reporter");
 

--- a/citations/dc_stat.js
+++ b/citations/dc_stat.js
@@ -1,0 +1,25 @@
+module.exports = {
+  type: "regex",
+
+  // normalize all cites to an ID
+  id: function(cite) {
+    return ["dcstat", cite.volume, cite.page].join("/")
+  },
+
+  patterns: [
+    // "20 DCSTAT 1952"
+    {
+      regex:
+        "(\\d+)\\s+" +
+        "DCSTAT" +
+        "\\s+(\\d+)",
+      fields: ['volume', 'page'],
+      processor: function(match) {
+        return {
+          volume: match.volume,
+          page: match.page,
+        };
+      }
+    }
+  ]
+};

--- a/citations/reporter.js
+++ b/citations/reporter.js
@@ -10,7 +10,7 @@ module.exports = {
     {
       regex:
         "(\\d{1,3})\\s" +
-        "(\\w+(?:\\.\\w+(?:\\.)?)?(?:\\.\\dd)?|U\\.?S\\.?|F\\. Supp\\.(?:\\s\\dd)?)\\s" +
+        "(\\w+(?:\\.\\w+(?:\\.)?)?(?:\\.\\dd)?|U\\.?\\s?S\\.?|F\\. Supp\\.(?:\\s\\dd)?)\\s" +
         "(\\d{1,4})",
       fields: ['volume',  'reporter', 'page'],
       processor: function(match) {

--- a/test/dc_stat.js
+++ b/test/dc_stat.js
@@ -1,0 +1,33 @@
+/*
+  Tests for extracting Statutes at Large citations.
+  Each test should link to a real world circumstance where possible.
+*/
+
+var Citation = require('../citation');
+
+exports["All patterns"] = function(test) {
+  var cases = [
+      // 
+      ["20 DCSTAT 548", "Basic citation", "20 DCSTAT 548",
+      "20", "548", "dcstat/20/548"]  ]
+
+  for (var i=0; i<cases.length; i++) {
+    var details = cases[i];
+
+    var text = details[0];
+    var found = Citation.find(text, {types: "dc_stat"}).citations;
+    test.equal(found.length, 1);
+
+    if (found.length == 1) {
+      var citation = found[0];
+      test.equal(citation.match, details[2]);
+      test.equal(citation.dc_stat.id, details[5]);
+      test.equal(citation.dc_stat.volume, details[3]);
+      test.equal(citation.dc_stat.page, details[4]);
+    }
+    else
+      console.log("No match found in: " + text);;
+  };
+
+  test.done();
+};

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -13,6 +13,13 @@ exports["Absolute patterns"] = function(test) {
       '558 U.S. 310',
       '558', 'U.S.', '310'],
 
+    // Supreme Court Opinion with extra space
+    [ 'US Reporter Spacing',
+      'Citizens United v. Federal Election Commission, 558 U. S. 310 (2010), (Docket No. 08-205), is a U.S. constitutional law case dealing with the regulation of campaign spending by corporations',
+  '558 U. S. 310',
+  '558', 'U. S.', '310'],
+
+
       //  Atlantic Reporter
       ["Atlantic",
       "In enacting the 1984 amendment, Congress undertook to authorize the Council in certain circumstances to do by resolution what the Congress itself could not do in its capacity as a national legislature. Cf. Gary v. United States, 499 A.2d 815, 818-821 (D.C.1985) (en banc)....",


### PR DESCRIPTION
Added new dc_stat citation type and a test for the basic form of `20 DCSTAT 101`.

Also, in a different commit, added an optional space for US Reports, so `510 U. S. 310` would work.