### PR TITLE
add a new 'links' field to matched citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ matches with citations broken out into fields.
 * `parents`: (boolean) For any cite, return any "parent" cites alongside it. For example, matching "5 USC 552(b)(3)" would return 3 results - one for the parent section, one for `(b)`, and one for `(b)(3)`.
 * `filter`: (string) Enable [Filtering](#filtering).
 * `replace`: (function | object) Enable [Replacement](#replacement).
+* `links`: (boolean) [Include Links](#include-links).
 * Also: see [Cite-specific options](#cite-specific-options) to pass in options for a particular citation type.
 
 Some examples:
@@ -210,6 +211,8 @@ Opt-in to using `walverine` to search judicial cites with `--judicial`:
 cite --judicial "Smith v. Hardibble, 111 Cal.2d 222, 555, 558, 333 Cal.3d 444 (1988)"
 ```
 
+Add `--links` to [include links](#include-links) in the output.
+
 ## Replacement
 
 You can perform a "find-and-replace" with detected citations, by providing a `replace` callback to be executed on each citation, that returns the string to replace that citation.
@@ -232,6 +235,54 @@ click on <a href="http://www.law.cornell.edu/uscode/text/5/552">5 USC 552</a> to
 ```
 
 This feature is only available in the JavaScript API.
+
+## Include Links
+
+With the `links` option, each matched citation will include URLs to access the content of the citation on the web. For:
+
+```javascript
+Citation.find("pursuant to 5 U.S.C. 552(a)(1)(E) and", { links: true });
+```
+
+you will get back an extended object with permalinks:
+
+```javascript
+[{
+  "match": "5 U.S.C. 552(a)(1)(E)",
+  "type": "usc",
+  ...
+  "usc": {
+    "id": "usc/5/552/a/1/E",
+    ...
+    "links": {
+      "usgpo": {
+        "source": {
+          "name": "U.S. Government Publishing Office",
+          "abbreviation": "US GPO",
+          "link": "http://www.gpo.gov",
+          "authoritative": true,
+          "note": "2014 edition. Sub-section citation is not reflected in the link."
+        },
+        "pdf": "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc",
+        "html": "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc&link-type=html",
+        "landing": "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc&link-type=contentdetail"
+      },
+      "cornell_lii": {
+        "source": {
+          "name": "Cornell Legal Information Institute",
+          "abbreviation": "Cornell LII",
+          "link": "https://www.law.cornell.edu/uscode/text",
+          "authoritative": false,
+          "note": "Link is to most current version of the US Code, as available at law.cornell.edu."
+        },
+        "landing": "https://www.law.cornell.edu/uscode/text/5/552#a_1_E"
+      }
+    }
+  }
+}]
+```
+
+The `links` object maps sources to one or more renditions. The rendition types are `pdf`, `html` (for raw HTML content), `landing` for a landing page (i.e. a website) about the document refered to by the citation, and `mods` (US GPO MODS XML files).
 
 ## Cite-specific options
 

--- a/bin/cite
+++ b/bin/cite
@@ -7,7 +7,7 @@ var citation = require('../citation');
 
 // load in options, allow a couple booleans
 var options = minimist(process.argv, {
-  boolean: ["judicial", "parents"]
+  boolean: ["judicial", "parents", "links"]
 });
 var text = options._[2];
 delete options._;

--- a/citation.js
+++ b/citation.js
@@ -209,7 +209,7 @@ Citation = {
           // by the citator
           result[type] = cite;
           result[type].id = Citation.types[type].id(cite);
-          if (result[type].id && 'links' in Citation.types[type])
+          if (options.links && result[type].id && 'links' in Citation.types[type])
             result[type].links = Citation.types[type].links(cite);
 
           results.push(result);

--- a/citation.js
+++ b/citation.js
@@ -205,9 +205,12 @@ Citation = {
           if ('canonical' in Citation.types[type])
             result.citation = Citation.types[type].canonical(cite);
 
-          // cite-level info, plus ID standardization
+          // cite-level info, plus ID standardization and permalinks if supported
+          // by the citator
           result[type] = cite;
           result[type].id = Citation.types[type].id(cite);
+          if (result[type].id && 'links' in Citation.types[type])
+            result[type].links = Citation.types[type].links(cite);
 
           results.push(result);
 

--- a/citations/cfr.js
+++ b/citations/cfr.js
@@ -73,5 +73,24 @@ module.exports = {
     //     };
     //   }
     // }
-  ]
+  ],
+
+  links: function(cite) {
+    var gpo_url = "http://api.fdsys.gov/link?collection=cfr&titlenum=" +
+        cite.title + "&partnum=" + cite.part + "&sectionnum="
+        cite.section + "&year=mostrecent"
+    var ret = {
+      usgpo: {
+        _source: {
+            name: "U.S. Government Publishing Office",
+            abbrev: "US GPO",
+            link: "http://gpo.gov/",
+            authoritative: true
+        },
+        pdf: gpo_url
+      }
+    };
+
+    return ret;
+  }
 };

--- a/citations/cfr.js
+++ b/citations/cfr.js
@@ -77,20 +77,20 @@ module.exports = {
 
   links: function(cite) {
     var gpo_url = "http://api.fdsys.gov/link?collection=cfr&titlenum=" +
-        cite.title + "&partnum=" + cite.part + "&sectionnum="
-        cite.section + "&year=mostrecent"
-    var ret = {
+        cite.title + "&partnum=" + cite.part + "&sectionnum=" +
+        cite.section + "&year=mostrecent";
+
+    return {
       usgpo: {
-        _source: {
+        source: {
             name: "U.S. Government Publishing Office",
-            abbrev: "US GPO",
-            link: "http://gpo.gov/",
+            abbreviation: "US GPO",
+            link: "http://www.gpo.gov",
             authoritative: true
         },
+
         pdf: gpo_url
       }
     };
-
-    return ret;
   }
 };

--- a/citations/dc_code.js
+++ b/citations/dc_code.js
@@ -90,6 +90,31 @@ module.exports = {
         }
       }
     ];
+  },
+
+  links: function(cite) {
+    return {
+      dccodeorg: {
+        source: {
+            name: "DCCode.org",
+            abbreviation: "DCCode.org",
+            link: "http://www.dccode.org",
+            authoritative: false
+        },
+
+        landing: "http://dccode.org/simple/sections/" + cite.title + "-" + cite.section + ".html"
+      },
+      dcdecoded: {
+        source: {
+            name: "DC Decoded",
+            abbreviation: "DCDecoded.org",
+            link: "http://dcdecoded.org",
+            authoritative: false
+        },
+
+        landing: "http://dcdecoded.org/" + cite.title + "-" + cite.section + "/"
+      }
+    };
   }
 };
 

--- a/citations/dc_law.js
+++ b/citations/dc_law.js
@@ -14,8 +14,8 @@ module.exports = {
       context_regex = "(?:" + context_regex + ")?"
 
     return [
-      // "D.C. Law 111-89"
-      // "DC Law 111-89"
+      // "D.C. Law 20-17"
+      // "DC Law 20-17"
       // "DC Law 18-135A"
       {
         regex:
@@ -29,5 +29,22 @@ module.exports = {
         }
       }
     ];
+  },
+
+  links: function(cite) {
+    // Only available for CP's 19 and 20.
+    if (cite.period < 19 || cite.period > 20) return { };
+    return {
+      dccodeorg: {
+        source: {
+            name: "Council of the District of Columbia",
+            abbreviation: "DC Council",
+            link: "https://dccode.gov",
+            authoritative: true
+        },
+
+        pdf: "https://dcstat.dccode.gov/public/Law_" + cite.period + "-" + cite.number + ".pdf"
+      }
+    };
   }
 };

--- a/citations/fedreg.js
+++ b/citations/fedreg.js
@@ -6,6 +6,7 @@ module.exports = {
     return ["fedreg", cite.volume, cite.page].join("/")
   },
 
+
   patterns: [
     // "75 Fed. Reg. 28404"
     // "69 FR 22135"
@@ -22,5 +23,22 @@ module.exports = {
         };
       }
     }
-  ]
+  ],
+
+  links: function(cite) {
+    var gpo_url = "http://api.fdsys.gov/link?collection=fr&volume=" + cite.volume + "&page=" + cite.page;
+    var ret = {
+      usgpo: {
+        _source: {
+            name: "U.S. Government Publishing Office",
+            abbrev: "US GPO",
+            link: "http://gpo.gov/",
+            authoritative: true
+        },
+        pdf: gpo_url
+      }
+    };
+
+    return ret;
+  }
 };

--- a/citations/fedreg.js
+++ b/citations/fedreg.js
@@ -27,18 +27,17 @@ module.exports = {
 
   links: function(cite) {
     var gpo_url = "http://api.fdsys.gov/link?collection=fr&volume=" + cite.volume + "&page=" + cite.page;
-    var ret = {
+    
+    return {
       usgpo: {
-        _source: {
-            name: "U.S. Government Publishing Office",
-            abbrev: "US GPO",
-            link: "http://gpo.gov/",
-            authoritative: true
+        source: {
+          name: "U.S. Government Publishing Office",
+          abbreviation: "US GPO",
+          link: "http://www.gpo.gov",
+          authoritative: true
         },
         pdf: gpo_url
       }
     };
-
-    return ret;
   }
 };

--- a/citations/law.js
+++ b/citations/law.js
@@ -74,29 +74,27 @@ module.exports = {
   ],
 
   links: function(cite) {
-    var ret = {
+    return {
       usgpo: {
-        _source: {
-            name: "U.S. Government Publishing Office",
-            abbrev: "US GPO",
-            link: "http://gpo.gov/",
-            authoritative: true
+        source: {
+          name: "U.S. Government Publishing Office",
+          abbreviation: "US GPO",
+          link: "http://www.gpo.gov",
+          authoritative: true
         },
         pdf: "http://api.fdsys.gov/link?collection=plaw&congress=" + cite.congress + "&lawtype=" + cite.type + "&lawnum=" + cite.number,
         mods: "http://api.fdsys.gov/link?collection=plaw&congress=" + cite.congress + "&lawtype=" + cite.type + "&lawnum=" + cite.number + "&link-type=mods"
       },
       
       govtrack: {
-        _source: {
-            name: "GovTrack.us",
-            abbrev: "GovTrack.us",
-            link: "https://www.govtrack.us/",
-            authoritative: false
+        source: {
+          name: "GovTrack.us",
+          abbreviation: "GovTrack.us",
+          link: "https://www.govtrack.us",
+          authoritative: false
         },
-        webpage: "https://www.govtrack.us/search?q=" + (cite.type=="public"?"Pub":"Priv") + "Law+" + cite.congress + "-" + cite.number
+        landing: "https://www.govtrack.us/search?q=" + (cite.type=="public"?"Pub":"Priv") + "Law+" + cite.congress + "-" + cite.number
       }
     };
-
-    return ret;
   }
 };

--- a/citations/law.js
+++ b/citations/law.js
@@ -71,5 +71,32 @@ module.exports = {
         };
       }
     }
-  ]
+  ],
+
+  links: function(cite) {
+    var ret = {
+      usgpo: {
+        _source: {
+            name: "U.S. Government Publishing Office",
+            abbrev: "US GPO",
+            link: "http://gpo.gov/",
+            authoritative: true
+        },
+        pdf: "http://api.fdsys.gov/link?collection=plaw&congress=" + cite.congress + "&lawtype=" + cite.type + "&lawnum=" + cite.number,
+        mods: "http://api.fdsys.gov/link?collection=plaw&congress=" + cite.congress + "&lawtype=" + cite.type + "&lawnum=" + cite.number + "&link-type=mods"
+      },
+      
+      govtrack: {
+        _source: {
+            name: "GovTrack.us",
+            abbrev: "GovTrack.us",
+            link: "https://www.govtrack.us/",
+            authoritative: false
+        },
+        webpage: "https://www.govtrack.us/search?q=" + (cite.type=="public"?"Pub":"Priv") + "Law+" + cite.congress + "-" + cite.number
+      }
+    };
+
+    return ret;
+  }
 };

--- a/citations/reporter.js
+++ b/citations/reporter.js
@@ -6,6 +6,10 @@ module.exports = {
     return ["reporter", cite.volume, cite.reporter, cite.page].join("/")
   },
 
+  canonical: function(cite) {
+    return cite.volume + " " + cite.reporter + " " + cite.page;
+  },
+
   patterns: [
     {
       regex:
@@ -21,5 +25,20 @@ module.exports = {
         };
       }
     }
-  ]
+  ],
+
+  links: function(cite) {
+    return {
+      courtlistener: {
+        source: {
+            name: "Court Listener",
+            abbreviation: "CL",
+            link: "https://www.courtlistener.com",
+            authoritative: false
+        },
+
+        landing: "https://www.courtlistener.com/?citation=" + encodeURIComponent(module.exports.canonical(cite))
+      }
+    };
+  }
 };

--- a/citations/stat.js
+++ b/citations/stat.js
@@ -26,5 +26,24 @@ module.exports = {
         };
       }
     }
-  ]
+  ],
+
+  links: function(cite) {
+    var usgpo_url = "http://api.fdsys.gov/link?collection=statute&volume=" + cite.volume + "&page=" + cite.page;
+
+    var ret = {
+      usgpo: {
+        _source: {
+            name: "U.S. Government Publishing Office",
+            abbrev: "US GPO",
+            link: "http://gpo.gov/",
+            authoritative: true
+        },
+        pdf: usgpo_url,
+        mods: usgpo_url + "&link-type=mods"
+      }
+    };
+
+    return ret;
+  }
 };

--- a/citations/stat.js
+++ b/citations/stat.js
@@ -31,19 +31,17 @@ module.exports = {
   links: function(cite) {
     var usgpo_url = "http://api.fdsys.gov/link?collection=statute&volume=" + cite.volume + "&page=" + cite.page;
 
-    var ret = {
+    return {
       usgpo: {
-        _source: {
+        source: {
             name: "U.S. Government Publishing Office",
-            abbrev: "US GPO",
-            link: "http://gpo.gov/",
+            abbreviation: "US GPO",
+            link: "http://www.gpo.gov",
             authoritative: true
         },
         pdf: usgpo_url,
         mods: usgpo_url + "&link-type=mods"
       }
     };
-
-    return ret;
   }
 };

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -125,48 +125,54 @@ module.exports = {
 
   links: function(cite) {
     // US GPO
-    var title_without_app = cite.title.replace(/-app$/, '');
-    var ret = { };
+    var title = cite.title.replace(/-app$/, '');
+    var links = {};
+
+    var edition;
     for (var i = 0; i < us_code_editions.length; i++) {
-        if (us_code_editions[i].titles == null
-            || us_code_editions[i].titles.indexOf(title_without_app) >= 0) {
-            // This edition contains the title.
-            var url = "http://api.fdsys.gov/link?collection=uscode&year="
-              + us_code_editions[i].edition + "&title=" + title_without_app
-              + "&section=" + cite.section
-              + "&type=" + (cite.title.indexOf("-app") == -1 ? "usc" : "uscappendix");
-            ret['usgpo'] = {
-                _source: {
-                    name: "U.S. Government Publishing Office",
-                    abbrev: "US GPO",
-                    link: "http://gpo.gov/",
-                    authoritative: true,
-                    note: us_code_editions[i].edition + " edition." + ((cite.subsections&&cite.subsections.length) ? " Sub-section citation is not reflected in the link." : "")
-                },
-                pdf: url,
-                html: url + "&link-type=html",
-                webpage: url + "&link-type=contentdetail",
-            };
-            break;
+        if (us_code_editions[i].titles == null || us_code_editions[i].titles.indexOf(title) >= 0) {
+          // This edition contains the title.
+          edition = us_code_editions[i]
+          break;
         }
+    }
+
+    if (edition) {
+      var url = "http://api.fdsys.gov/link?collection=uscode&year="
+        + edition.edition + "&title=" + title
+        + "&section=" + cite.section
+        + "&type=" + (cite.title.indexOf("-app") == -1 ? "usc" : "uscappendix");
+      
+      links.usgpo = {
+          source: {
+              name: "U.S. Government Publishing Office",
+              abbreviation: "US GPO",
+              link: "http://www.gpo.gov",
+              authoritative: true,
+              note: edition.edition + " edition." + ((cite.subsections && cite.subsections.length) ? " Sub-section citation is not reflected in the link." : "")
+          },
+          pdf: url,
+          html: url + "&link-type=html",
+          landing: url + "&link-type=contentdetail",
+      };
     }
 
     // Cornell Legal Information Institute
     // (for current citations only, i.e. not tied to a publication or effective date)
-    ret['cornell_lii'] = {
-        _source: {
+    links.cornell_lii = {
+        source: {
             name: "Cornell Legal Information Institute",
-            abbrev: "Cornell LII",
+            abbreviation: "Cornell LII",
             link: "https://www.law.cornell.edu/uscode/text",
             authoritative: false,
             note: "Link is to most current version of the US Code, as available at law.cornell.edu."
         },
-        webpage: "http://www.law.cornell.edu/uscode/text/" + (title_without_app + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
+        html: "https://www.law.cornell.edu/uscode/text/" + (title + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
                           + "/" + cite.section
-                          + ((cite.subsections&&cite.subsections.length) ? ("#" + cite.subsections.join("_")) : "")
+                          + ((cite.subsections && cite.subsections.length) ? ("#" + cite.subsections.join("_")) : "")
     };
 
-    return ret;
+    return links;
   }
 };
 

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -167,7 +167,7 @@ module.exports = {
             authoritative: false,
             note: "Link is to most current version of the US Code, as available at law.cornell.edu."
         },
-        html: "https://www.law.cornell.edu/uscode/text/" + (title + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
+        landing: "https://www.law.cornell.edu/uscode/text/" + (title + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
                           + "/" + cite.section
                           + ((cite.subsections && cite.subsections.length) ? ("#" + cite.subsections.join("_")) : "")
     };

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -121,5 +121,60 @@ module.exports = {
         };
       }
     }
-  ]
+  ],
+
+  links: function(cite) {
+    // US GPO
+    var title_without_app = cite.title.replace(/-app$/, '');
+    var ret = { };
+    for (var i = 0; i < us_code_editions.length; i++) {
+        if (us_code_editions[i].titles == null
+            || us_code_editions[i].titles.indexOf(title_without_app) >= 0) {
+            // This edition contains the title.
+            var url = "http://api.fdsys.gov/link?collection=uscode&year="
+              + us_code_editions[i].edition + "&title=" + title_without_app
+              + "&section=" + cite.section
+              + "&type=" + (cite.title.indexOf("-app") == -1 ? "usc" : "uscappendix");
+            ret['usgpo'] = {
+                _source: {
+                    name: "U.S. Government Publishing Office",
+                    abbrev: "US GPO",
+                    link: "http://gpo.gov/",
+                    authoritative: true,
+                    note: us_code_editions[i].edition + " edition." + ((cite.subsections&&cite.subsections.length) ? " Sub-section citation is not reflected in the link." : "")
+                },
+                pdf: url,
+                html: url + "&link-type=html",
+                webpage: url + "&link-type=contentdetail",
+            };
+            break;
+        }
+    }
+
+    // Cornell Legal Information Institute
+    // (for current citations only, i.e. not tied to a publication or effective date)
+    ret['cornell_lii'] = {
+        _source: {
+            name: "Cornell Legal Information Institute",
+            abbrev: "Cornell LII",
+            link: "https://www.law.cornell.edu/uscode/text",
+            authoritative: false,
+            note: "Link is to most current version of the US Code, as available at law.cornell.edu."
+        },
+        webpage: "http://www.law.cornell.edu/uscode/text/" + (title_without_app + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
+                          + "/" + cite.section
+                          + ((cite.subsections&&cite.subsections.length) ? ("#" + cite.subsections.join("_")) : "")
+    };
+
+    return ret;
+  }
 };
+
+// Map published editions of the US Code to the titles they contain. Not all
+// published editions have the full US Code. Some are updates. This is per
+// http://www.gpo.gov/fdsys/browse/collectionUScode.action?collectionCode=USCODE.
+// Most recent first.
+var us_code_editions = [
+    { edition: '2014', titles: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15'] },
+    { edition: '2013', titles: null }, // all titles available in this edition
+];

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -159,6 +159,8 @@ module.exports = {
 
     // Cornell Legal Information Institute
     // (for current citations only, i.e. not tied to a publication or effective date)
+    var subsections = (cite.subsections.slice() || []); // clone
+    if (subsections.length && subsections[subsections.length-1] == "et-seq") subsections.pop(); // don't include eq-seq in a link
     links.cornell_lii = {
         source: {
             name: "Cornell Legal Information Institute",
@@ -169,7 +171,7 @@ module.exports = {
         },
         landing: "https://www.law.cornell.edu/uscode/text/" + (title + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
                           + "/" + cite.section
-                          + ((cite.subsections && cite.subsections.length) ? ("#" + cite.subsections.join("_")) : "")
+                          + (subsections.length ? ("#" + subsections.join("_")) : "")
     };
 
     return links;

--- a/citations/va_code.js
+++ b/citations/va_code.js
@@ -31,5 +31,20 @@ module.exports = {
         };
       }
     }
-  ]
+  ],
+
+  links: function(cite) {
+    return {
+      vadecoded: {
+        source: {
+            name: "Virginia Decoded",
+            abbreviation: "VACode.org",
+            link: "https://vacode.org",
+            authoritative: false
+        },
+
+        landing: "https://vacode.org/" + cite.title + "-" + cite.section + "/"
+      }
+    };
+  }
 };

--- a/test/dc_code.js
+++ b/test/dc_code.js
@@ -12,43 +12,43 @@ exports["Relative patterns"] = function(test) {
     [ 'standard',
       'as that term is defined in § 32-701(4), to the deceased',
       '§ 32-701(4)',
-      '32', '701', ['4']],
+      '32', '701', ['4'], "http://dccode.org/simple/sections/32-701.html"],
 
     // in 3-101 of the DC Code:
     [ 'into-newline',
       'as provided in § 1-603.01(13).\n\n(b) In addition to the',
       '§ 1-603.01(13)',
-      '1', '603.01', ['13']],
+      '1', '603.01', ['13'], "http://dccode.org/simple/sections/1-603.01.html"],
 
     // in 3-101 of the DC Code
     [ 'section-with-dot',
       'required under § 3-101.01, the Commission',
       '§ 3-101.01',
-      '3', '101.01', []],
+      '3', '101.01', [], "http://dccode.org/simple/sections/3-101.01.html"],
 
     // in 1-611.1 of the DC Code
     [ 'section-ending-with-dot',
       'accordance with the policies of § 1-611.01.',
       '§ 1-611.01',
-      '1', '611.01', []],
+      '1', '611.01', [], "http://dccode.org/simple/sections/1-611.01.html"],
 
     // in 1-1163.20 of the DC Code
     [ 'section-forgiving-with-space',
       'contribution limits for the candidate as provided under § 1- 1163.33.',
       '§ 1- 1163.33',
-      '1', '1163.33', []],
+      '1', '1163.33', [], "http://dccode.org/simple/sections/1-1163.33.html"],
 
     // hypothetical (modified from 1-1163.20 of the DC Code)
     [ 'section-forgiving-with-space',
       'contribution limits for the candidate as provided under § 1 -1163.33.',
       '§ 1 -1163.33',
-      '1', '1163.33', []],
+      '1', '1163.33', [], "http://dccode.org/simple/sections/1-1163.33.html"],
 
     // in 16-316 of the DC Code
     [ 'section-with-word-section',
       'case shall be subject to the limitation set forth in [section 16-2326.01(b)(2)].',
       'section 16-2326.01(b)(2)',
-      '16', '2326.01', ['b', '2']]
+      '16', '2326.01', ['b', '2'], "http://dccode.org/simple/sections/16-2326.01.html"]
   ];
 
   for (var i=0; i<cases.length; i++) {
@@ -57,6 +57,7 @@ exports["Relative patterns"] = function(test) {
 
     var found = Citation.find(text, {
       types: ["dc_code"],
+      links: true,
 
       // ensures we'll detect relative cites
       dc_code: {source: "dc_code"}
@@ -70,6 +71,7 @@ exports["Relative patterns"] = function(test) {
       test.equal(citation.dc_code.title, details[3]);
       test.equal(citation.dc_code.section, details[4]);
       test.deepEqual(citation.dc_code.subsections, details[5]);
+      test.equal(citation.dc_code.links.dccodeorg.landing, details[6]);
     } else
       console.log("No match found in: " + text);
 

--- a/test/stat.js
+++ b/test/stat.js
@@ -18,7 +18,7 @@ exports["All patterns"] = function(test) {
     var details = cases[i];
 
     var text = details[0];
-    var found = Citation.find(text, {types: "stat"}).citations;
+    var found = Citation.find(text, {types: "stat", links: true}).citations;
     test.equal(found.length, 1);
 
     if (found.length == 1) {
@@ -28,6 +28,7 @@ exports["All patterns"] = function(test) {
       test.equal(citation.stat.id, details[5]);
       test.equal(citation.stat.volume, details[3]);
       test.equal(citation.stat.page, details[4]);
+      test.equal(citation.stat.links.usgpo.source.link, "http://www.gpo.gov");
     }
     else
       console.log("No match found in: " + text);;

--- a/test/usc.js
+++ b/test/usc.js
@@ -10,7 +10,7 @@ exports["Basic pattern"] = function(test) {
   // http://www.gpo.gov/fdsys/pkg/BILLS-112hr3604ih/xml/BILLS-112hr3604ih.xml
   var text = "of the Administrative Procedure Act (5 U.S.C. 552) and some";
 
-  var found = Citation.find(text, {types: "usc"}).citations;
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
   test.equal(found.length, 1);
 
   var citation = found[0];
@@ -21,6 +21,8 @@ exports["Basic pattern"] = function(test) {
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/5/552");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/5/552");
 
   var foundExcerpt = Citation.find(text, {types: "usc", excerpt: 5}).citations;
   test.equal(foundExcerpt.length, 1);
@@ -65,7 +67,7 @@ exports["Basic subsection parsing"] = function(test) {
     "the authority of this section shall be repealed in accordance " +
     "... of the Administrative Procedure Act (5 U.S.C. 552(a)(1)(E)) ...";
 
-  var found = Citation.find(text, {types: "usc"}).citations;
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
   test.equal(found.length, 1);
 
   var citation = found[0];
@@ -75,6 +77,8 @@ exports["Basic subsection parsing"] = function(test) {
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, ["a", "1", "E"])
   test.equal(citation.usc.id, "usc/5/552/a/1/E");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/5/552#a_1_E");
 
   test.done();
 }
@@ -184,7 +188,7 @@ exports["'Appendix' titles"] = function(test) {
   // http://www.gpo.gov/fdsys/pkg/BILLS-112s3608is/xml/BILLS-112s3608is.xml
   var text = "Civil Relief Act (50 U.S.C. App. 595) is amended"
 
-  var found = Citation.find(text, {types: "usc"}).citations;
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
   test.equal(found.length, 1);
 
   var citation = found[0];
@@ -194,6 +198,8 @@ exports["'Appendix' titles"] = function(test) {
   test.equal(citation.usc.section, "595");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/50-app/595");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=50&section=595&type=uscappendix");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/50a/595");
 
   test.done();
 };
@@ -202,7 +208,7 @@ exports["'note' marks"] = function(test) {
   // http://www.gpo.gov/fdsys/pkg/BILLS-112hr6567ih/xml/BILLS-112hr6567ih.xml
   var text = "commodity supplemental food program) (7 U.S.C. 612c note).";
 
-  var found = Citation.find(text, {types: "usc"}).citations;
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
   test.equal(found.length, 1);
 
   var citation = found[0];
@@ -212,6 +218,8 @@ exports["'note' marks"] = function(test) {
   test.equal(citation.usc.section, "612c");
   test.deepEqual(citation.usc.subsections, ["note"])
   test.equal(citation.usc.id, "usc/7/612c/note");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=7&section=612c&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/7/612c#note"); // incorrect but close enough
 
   test.done();
 }
@@ -221,7 +229,7 @@ exports["'et seq' marks"] = function(test) {
   // from http://www.gpo.gov/fdsys/pkg/BILLS-113s1302rs/html/BILLS-113s1302rs.htm
   var text = "the Employee Retirement Income Security Act of 1974 (29 U.S.C. 1081 et seq.)";
 
-  var found = Citation.find(text, {types: "usc"}).citations;
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
   test.equal(found.length, 1);
 
   var citation = found[0];
@@ -231,6 +239,8 @@ exports["'et seq' marks"] = function(test) {
   test.equal(citation.usc.section, "1081");
   test.deepEqual(citation.usc.subsections, ["et-seq"])
   test.equal(citation.usc.id, "usc/29/1081/et-seq");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=29&section=1081&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/29/1081");
 
   test.done();
 }

--- a/test/va_code.js
+++ b/test/va_code.js
@@ -10,42 +10,42 @@ exports["All patterns"] = function(test) {
     [ 'standard',
       'Va. Code Ann. § 19.2-56.2 (2010)',
       '19.2', '56.2', '2010',
-      'va-code/19.2/56.2'],
+      'va-code/19.2/56.2', 'https://vacode.org/19.2-56.2/'],
     [ 'standard-west',
       'Va. Code Ann. § 19.2-56.2 (West 2010)',
       '19.2', '56.2', '2010',
-      'va-code/19.2/56.2'],
+      'va-code/19.2/56.2', 'https://vacode.org/19.2-56.2/'],
     [ 'no-year-1',
       'Va. Code Ann. § 57-1',
       '57', '1', null,
-      'va-code/57/1'],
+      'va-code/57/1', 'https://vacode.org/57-1/'],
     [ 'no-year-2',
       'Va. Code Ann. § 57-2.02',
       '57', '2.02', null,
-      'va-code/57/2.02'],
+      'va-code/57/2.02', 'https://vacode.org/57-2.02/'],
     [ 'no-year-3',
       'Va. Code Ann. § 63.2-300',
       '63.2', '300', null,
-      'va-code/63.2/300'],
+      'va-code/63.2/300', 'https://vacode.org/63.2-300/'],
     [ 'section-with-colon',
       'Va. Code Ann. § 66-25.1:1',
       '66', '25.1:1', null,
-      'va-code/66/25.1:1'],
+      'va-code/66/25.1:1', 'https://vacode.org/66-25.1:1/'],
     [ 'No Annotation',
       "Va. Code § 66-25.1:1",
       "66", "25.1:1", null,
-      'va-code/66/25.1:1'],
+      'va-code/66/25.1:1', 'https://vacode.org/66-25.1:1/'],
     [ 'No Annotation or Period',
       "VA Code § 66-25.1:1",
       "66", "25.1:1", null,
-      'va-code/66/25.1:1']
+      'va-code/66/25.1:1', 'https://vacode.org/66-25.1:1/']
   ];
 
   for (var i=0; i<cases.length; i++) {
     var details = cases[i];
 
     var text = details[1];
-    var found = Citation.find(text, {types: ["va_code"]}).citations;
+    var found = Citation.find(text, {types: ["va_code"], links: true}).citations;
     test.equal(found.length, 1);
 
     if (found.length == 1) {
@@ -55,6 +55,7 @@ exports["All patterns"] = function(test) {
       test.equal(citation.va_code.section, details[3]);
       test.equal(citation.va_code.year, details[4]);
       test.equal(citation.va_code.id, details[5]);
+      test.equal(citation.va_code.links.vadecoded.landing, details[6]);
     } else
       console.log("No match found in: " + text);
   }


### PR DESCRIPTION
This PR adds a new `links` field to matched citations with information to generate a permalink. I've implemented this for US Code citations as:

	$ cite "40 U.S.C. § 11101(1)"
	{
	  "citations": [
	    {
	      "type": "usc",
	      "match": "40 U.S.C. § 11101(1)",
	      "index": 0,
	      "usc": {
	        "title": "40",
	        "section": "11101",
	        "subsections": [
	          "1"
	        ],
	        "id": "usc/40/11101/1",
	        "links": [
	          {
	            "source": "U.S. Government Publishing Office",
	            "source_abbrev": "US GPO",
	            "authoritative": true,
	            "note": "Sub-section citation is not included.",
	            "links": [
	              {
	                "url": "http://api.fdsys.gov/link?collection=uscode&year=2013&title=40&section=11101&type=usc",
	                "type": "pdf"
	              },
	              {
	                "url": "http://api.fdsys.gov/link?collection=uscode&year=2013&title=40&section=11101&type=usc&link-type=html",
	                "type": "html"
	              },
	              {
	                "url": "http://api.fdsys.gov/link?collection=uscode&year=2013&title=40&section=11101&type=usc&link-type=contentdetail",
	                "type": "other"
	              }
	            ]
	          },
	          {
	            "source": "Cornell Legal Information Institute",
	            "source_abbrev": "Cornell LII",
	            "authoritative": false,
	            "links": [
	              {
	                "url": "http://www.law.cornell.edu/uscode/text/40/11101#1"
	              }
	            ]
	          }
	        ]
	      }
	    }
	  ]
	}

The `links` array is a list of sources (e.g. US GPO, Cornell LII), each of which can offer one or more links in different formats (PDF, text, etc.).

I've left in an unused argument where we'd have to consider point-in-time issues: to create a permanent link to X USC Y as it is today, or as it was on a certain past date. The output links should probably also include information about their as-of date: for US GPO links, it would be the US Code edition date, but for Cornell LII links it would be a token indicating it's most-recently-published, since the LII URLs will always reflect the most recent publication they've updated to.

What do you all think?

This only took a few minutes to cook up, so no worries if you all think this should go in a separate module perhaps.