### PR TITLE
add a canonical 'citation' field to matched citations

### DIFF
--- a/citation.js
+++ b/citation.js
@@ -200,6 +200,11 @@ Citation = {
             delete cite._submatch;
           }
 
+          // since a single text region can match multiple citations, such as when
+          // a range is given, clarify what this match represents
+          if ('canonical' in Citation.types[type])
+            result.citation = Citation.types[type].canonical(cite);
+
           // cite-level info, plus ID standardization
           result[type] = cite;
           result[type].id = Citation.types[type].id(cite);

--- a/citations/law.js
+++ b/citations/law.js
@@ -7,6 +7,16 @@ module.exports = {
       .join("/");
   },
 
+  canonical: function(cite) {
+    if (!cite.sections || cite.sections.length == 0)
+      // this style matches GPO at http://www.gpo.gov/fdsys/browse/collection.action?collectionCode=PLAW&browsePath=112&isCollapsed=false&leafLevelBrowse=false&ycord=0
+      return (cite.type == "public" ? "Pub. L." : "Pvt. L.") + " " + cite.congress + "-" + cite.number;
+    else
+      return "Section " + cite.sections[0] + cite.sections.slice(1).map(function(item) { return "(" + item + ")" }).join("")
+        + " of " +
+        (cite.type == "public" ? "Public" : "Private") + " Law " + cite.congress + "-" + cite.number;
+  },
+
   // field to calculate parents from
   parents_by: "sections",
 

--- a/citations/stat.js
+++ b/citations/stat.js
@@ -6,6 +6,10 @@ module.exports = {
     return ["stat", cite.volume, cite.page].join("/")
   },
 
+  canonical: function(cite) {
+    return cite.volume + " Stat. " + cite.page;
+  },
+
   patterns: [
     // "117 Stat. 1952"
     // "77 STAT. 77"

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -7,6 +7,30 @@ module.exports = {
       .join("/");
   },
 
+  canonical: function(cite) {
+    // title, which alos may specify it is an appendix title
+    var title = cite.title;
+    var app = "";
+    var title_without_app = cite.title.replace(/-app$/, '');
+    if (title != title_without_app) app = "App. ";
+
+    // subsections, possibly with a note/et-seq as a leaf which should
+    // be rendered differently from a normal subsection item
+    var subsections = cite.subsections.slice(); // clone
+    var suffix = "";
+    var leaf = subsections.length > 0 ? subsections[subsections.length-1] : null;
+    if (leaf == "note") {
+      subsections.pop();
+      suffix = " note"
+    } else if (leaf == "et-seq") {
+      subsections.pop();
+      suffix = " et seq"
+    }
+
+    return title_without_app + " U.S.C. " + app + cite.section
+     + subsections.map(function(item) { return "(" + item + ")" }).join("")
+     + suffix;
+  },
 
   // field to calculate parents from
   parents_by: "subsections",

--- a/test/law.js
+++ b/test/law.js
@@ -10,47 +10,47 @@ exports["Basic patterns"] = function(test) {
   var cases = [
     // variations on text of http://www.gpo.gov/fdsys/pkg/BILLS-112hr2367ih/xml/BILLS-112hr2367ih.xml
     ["Pub. L. 96–164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Pub. L. 96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Pub. L. 96–164; ", "Pub. L. 96-164"],
     ["Pub. L. 96-164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Pub. L. 96-164; "],
+      "Nuclear Energy Authorization Act of 1980 (Pub. L. 96-164; ", "Pub. L. 96-164"],
     ["Pub. L. No. 96-164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Pub. L. No. 96-164; "],
+      "Nuclear Energy Authorization Act of 1980 (Pub. L. No. 96-164; ", "Pub. L. 96-164"],
     ["Pub L 96–164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Pub L 96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Pub L 96–164; ", "Pub. L. 96-164"],
     ["Pub L No 96-164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Pub L No 96-164; "],
+      "Nuclear Energy Authorization Act of 1980 (Pub L No 96-164; ", "Pub. L. 96-164"],
     ["Public Law 96–164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Public Law 96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Public Law 96–164; ", "Pub. L. 96-164"],
     ["Public   Law  96–164", "us-law/public/96/164", "public", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Public   Law  96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Public   Law  96–164; ", "Pub. L. 96-164"],
 
     // from DC Code credits for 1-201.01
     ["Pub.L. 105-33", "us-law/public/105/33", "public", "105", "33",
-      "111 Stat. 251, Pub.L. 105-33, title XI"],
+      "111 Stat. 251, Pub.L. 105-33, title XI", "Pub. L. 105-33"],
     ["Pub.L.No. 105-33", "us-law/public/105/33", "public", "105", "33",
-      "111 Stat. 251, Pub.L.No. 105-33, title XI"], // made-up
+      "111 Stat. 251, Pub.L.No. 105-33, title XI", "Pub. L. 105-33"], // made-up
 
     // summary for http://beta.congress.gov/bill/112th/house-bill/1
     ["P.L. 111-80", "us-law/public/111/80", "public", "111", "80",
-      "Related Agencies Appropriations Act, 2010 (P.L. 111-80);"],
+      "Related Agencies Appropriations Act, 2010 (P.L. 111-80);", "Pub. L. 111-80"],
     ["PL 111-83", "us-law/public/111/83", "public", "111", "83",
-      "Homeland Security Appropriations Act, 2010 (PL 111-83);"],
+      "Homeland Security Appropriations Act, 2010 (PL 111-83);", "Pub. L. 111-83"],
     ["PL   111-83", "us-law/public/111/83", "public", "111", "83",
-      "Homeland Security Appropriations Act, 2010 (PL   111-83);"],
+      "Homeland Security Appropriations Act, 2010 (PL   111-83);", "Pub. L. 111-83"],
 
     // don't have a source for these yet, just theoretical
     ["Priv. L. 96–164", "us-law/private/96/164", "private", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Priv. L. 96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Priv. L. 96–164; ", "Pvt. L. 96-164"],
     ["Priv. L. 96-164", "us-law/private/96/164", "private", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Priv. L. 96-164; "],
+      "Nuclear Energy Authorization Act of 1980 (Priv. L. 96-164; ", "Pvt. L. 96-164"],
     ["Priv. L. No. 96-164", "us-law/private/96/164", "private", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Priv. L. No. 96-164; "],
+      "Nuclear Energy Authorization Act of 1980 (Priv. L. No. 96-164; ", "Pvt. L. 96-164"],
     ["Priv L 96–164", "us-law/private/96/164", "private", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Priv L 96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Priv L 96–164; ", "Pvt. L. 96-164"],
     ["Priv L No 96-164", "us-law/private/96/164", "private", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Priv L No 96-164; "],
+      "Nuclear Energy Authorization Act of 1980 (Priv L No 96-164; ", "Pvt. L. 96-164"],
     ["Private Law 96–164", "us-law/private/96/164", "private", "96", "164",
-      "Nuclear Energy Authorization Act of 1980 (Private Law 96–164; "],
+      "Nuclear Energy Authorization Act of 1980 (Private Law 96–164; ", "Pvt. L. 96-164"],
   ];
 
   for (var i=0; i<cases.length; i++) {
@@ -63,6 +63,7 @@ exports["Basic patterns"] = function(test) {
     if (found.length == 1) {
       var citation = found[0];
       test.equal(citation.match, details[0]);
+      test.equal(citation.citation, details[6]);
       test.equal(citation.law.id, details[1]);
       test.equal(citation.law.type, details[2]);
       test.equal(citation.law.congress, details[3]);
@@ -78,13 +79,13 @@ exports["Subsections"] = function(test) {
     // variations on text of http://www.gpo.gov/fdsys/pkg/BILLS-112hr6567ih/xml/BILLS-112hr6567ih.xml
     ["Section 4402 of Public Law 107–171", "us-law/public/107/171/4402",
       "public", "107", "171", ["4402"],
-      "(3) Section 4402 of Public Law 107–171 (relating"],
+      "(3) Section 4402 of Public Law 107–171 (relating", "Section 4402 of Public Law 107-171"],
     ["Section 4402(e) of PL 107–171", "us-law/public/107/171/4402/e",
       "public", "107", "171", ["4402", "e"],
-      "(3) Section 4402(e) of PL 107–171 (relating"],
+      "(3) Section 4402(e) of PL 107–171 (relating", "Section 4402(e) of Public Law 107-171"],
     ["Section 4402(e)(1) of Public Law 107–171", "us-law/public/107/171/4402/e/1",
       "public", "107", "171", ["4402", "e", "1"],
-      "(3) Section 4402(e)(1) of Public Law 107–171 (relating"]
+      "(3) Section 4402(e)(1) of Public Law 107–171 (relating", "Section 4402(e)(1) of Public Law 107-171"]
   ];
 
 
@@ -98,6 +99,7 @@ exports["Subsections"] = function(test) {
     if (found.length == 1) {
       var citation = found[0];
       test.equal(citation.match, details[0]);
+      test.equal(citation.citation, details[7]);
       test.equal(citation.law.id, details[1]);
       test.equal(citation.law.type, details[2]);
       test.equal(citation.law.congress, details[3]);

--- a/test/stat.js
+++ b/test/stat.js
@@ -9,9 +9,9 @@ exports["All patterns"] = function(test) {
   var cases = [
       // text copied from the DC Code Credits
       ["110 Stat. 548", "Basic citation", "110 Stat. 548",
-      "110", "548", "stat/110/548"],
+      "110", "548", "stat/110/548", "110 Stat. 548"],
       ["Mar. 3, 1887, 24 Stat. 501, ch. 355", "DC Code Credits",
-      "24 Stat. 501", "24", "501", "stat/24/501"],
+      "24 Stat. 501", "24", "501", "stat/24/501", "24 Stat. 501"],
   ]
 
   for (var i=0; i<cases.length; i++) {
@@ -24,6 +24,7 @@ exports["All patterns"] = function(test) {
     if (found.length == 1) {
       var citation = found[0];
       test.equal(citation.match, details[2]);
+      test.equal(citation.citation, details[6]);
       test.equal(citation.stat.id, details[5]);
       test.equal(citation.stat.volume, details[3]);
       test.equal(citation.stat.page, details[4]);

--- a/test/usc.js
+++ b/test/usc.js
@@ -16,6 +16,7 @@ exports["Basic pattern"] = function(test) {
   var citation = found[0];
   test.equal(citation.match, "5 U.S.C. 552");
   test.equal(citation.index, 37);
+  test.equal(citation.citation, "5 U.S.C. 552");
   test.equal(citation.usc.title, "5");
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, [])
@@ -34,6 +35,7 @@ exports["Basic pattern"] = function(test) {
   test.equal(foundSmall.length, 1);
   test.equal(foundSmall[0].match, "5 usc 552")
   test.equal(foundSmall[0].excerpt, "5 usc 552")
+  test.equal(foundSmall[0].citation, "5 U.S.C. 552")
   test.equal(foundSmall[0].index, 0)
 
   test.done();
@@ -68,6 +70,7 @@ exports["Basic subsection parsing"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "5 U.S.C. 552(a)(1)(E)");
+  test.equal(citation.citation, "5 U.S.C. 552(a)(1)(E)");
   test.equal(citation.usc.title, "5");
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, ["a", "1", "E"])
@@ -88,6 +91,7 @@ exports["Casual pattern"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "section 89 of title 14");
+  test.equal(citation.citation, "14 U.S.C. 89");
   test.equal(citation.usc.title, "14");
   test.equal(citation.usc.section, "89");
   test.deepEqual(citation.usc.subsections, [])
@@ -108,6 +112,7 @@ exports["Casual pattern"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "section 89, title 14");
+  test.equal(citation.citation, "14 U.S.C. 89");
   test.equal(citation.usc.title, "14");
   test.equal(citation.usc.section, "89");
   test.deepEqual(citation.usc.subsections, [])
@@ -127,6 +132,7 @@ exports["Casual pattern (with subsections)"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "section 5362(5) of title 31");
+  test.equal(citation.citation, "31 U.S.C. 5362(5)");
   test.equal(citation.usc.title, "31");
   test.equal(citation.usc.section, "5362");
   test.deepEqual(citation.usc.subsections, ["5"])
@@ -142,6 +148,7 @@ exports["Casual pattern (with subsections)"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "section 5362-10c(5) of title 31");
+  test.equal(citation.citation, "31 U.S.C. 5362-10c(5)");
   test.equal(citation.usc.title, "31");
   test.equal(citation.usc.section, "5362-10c");
   test.deepEqual(citation.usc.subsections, ["5"])
@@ -164,6 +171,7 @@ exports["Section symbol is ignored"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "5 USC § 552");
+  test.equal(citation.citation, "5 U.S.C. 552");
   test.equal(citation.usc.title, "5");
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, [])
@@ -181,6 +189,7 @@ exports["'Appendix' titles"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "50 U.S.C. App. 595");
+  test.equal(citation.citation, "50 U.S.C. App. 595");
   test.equal(citation.usc.title, "50-app");
   test.equal(citation.usc.section, "595");
   test.deepEqual(citation.usc.subsections, [])
@@ -198,6 +207,7 @@ exports["'note' marks"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "7 U.S.C. 612c note");
+  test.equal(citation.citation, "7 U.S.C. 612c note");
   test.equal(citation.usc.title, "7");
   test.equal(citation.usc.section, "612c");
   test.deepEqual(citation.usc.subsections, ["note"])
@@ -216,6 +226,7 @@ exports["'et seq' marks"] = function(test) {
 
   var citation = found[0];
   test.equal(citation.match, "29 U.S.C. 1081 et seq");
+  test.equal(citation.citation, "29 U.S.C. 1081 et seq");
   test.equal(citation.usc.title, "29");
   test.equal(citation.usc.section, "1081");
   test.deepEqual(citation.usc.subsections, ["et-seq"])
@@ -376,6 +387,7 @@ exports["Ranges: basic subsections"] = function(test) {
   if (found.length == 1) {
     var citation = found[0];
     test.equal(citation.match, "31 U.S.C. 5318A(b)(l)");
+    test.equal(citation.citation, "31 U.S.C. 5318A(b)(l)");
     test.equal(citation.usc.title, "31");
     test.equal(citation.usc.section, "5318A");
     test.deepEqual(citation.usc.subsections, ["b", "l"])


### PR DESCRIPTION
One more....

Some citations return multiple matches for the same text range. So that the user can distinguish what's being returned, this adds a `citation` field with human-readable citation text in canonical form to matches, for the usc, law, and statute citators.

Example:

	$ bin/cite "40 U.S.C. App § 11101(1)(a)-105(b)"
	{
	"citations": [
		{
			"type": "usc",
			"match": "40 U.S.C. App § 11101(1)(a)-105(b)",
			"index": 0,
			"usc": { ... },
			"citation": "40-app U.S.C. App. 11101(1)(a)"
		},
		{
			"type": "usc",
			"match": "40 U.S.C. App § 11101(1)(a)-105(b)",
			"index": 0,
			"usc": { ... },
			"citation": "40-app U.S.C. App. 105(b)"
		}
	]
	}

