### PR TITLE
Allow section symbols without trailing spaces

### DIFF
--- a/citations/dc_code.js
+++ b/citations/dc_code.js
@@ -33,8 +33,8 @@ module.exports = {
     // section 16-2326.01
 
     var prefix_regex = "";
-    var section_regex = "(?:sections?|§+)\\s+";
-    var sections_regex = "(?:sections|§§)\\s+";
+    var section_regex = "(?:sections?\\s+|§+\\s*)";
+    var sections_regex = "(?:sections\\s+|§§\\s*)";
     if (context.source != "dc_code") {
       // Require "DC Official Code" but then make the section symbol optional.
       prefix_regex = "D\\.?C\\.? (?:Official )?Code\\s+";

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -49,9 +49,9 @@ module.exports = {
       regex:
         "(\\d+)\\s+" + // title
         "U\\.?\\s?S\\.?\\s?C\\.?" +
-        "(?:\\s+(App)\.?)?" + // appendix
-        "(?:\\s+(§+))?" + // symbol
-        "\\s+((?:\\-*\\d+[\\w\\d\\-]*(?:\\([^\\)]+\\))*)+)" + // sections
+        "(?:\\s+(App)\.?)?\\s+" + // appendix
+        "(?:(§+)\\s*)?" + // symbol
+        "((?:\\-*\\d+[\\w\\d\\-]*(?:\\([^\\)]+\\))*)+)" + // sections
         "(?:\\s+(note|et\\s+seq))?", // note
 
       fields: [

--- a/citations/va_code.js
+++ b/citations/va_code.js
@@ -18,9 +18,9 @@ module.exports = {
     {
       regex:
         "Va\\.? Code\\.?" +
-        "(?:\\s+Ann\\.?)?" +
-        "(?:\\s+§+)?" +
-        "\\s+([\\d\\.]+)\\-([\\d\\.:]+)" +
+        "(?:\\s+Ann\\.?)?\\s+" +
+        "(?:§+\\s*)?" +
+        "([\\d\\.]+)\\-([\\d\\.:]+)" +
         "(?:\\s+\\((?:West )?([12]\\d{3})\\))?",
       fields: ['title', 'section', 'year'],
       processor: function (captures) {

--- a/test/cfr.js
+++ b/test/cfr.js
@@ -48,6 +48,20 @@ var singles = [
     }
   ],
 
+  // Artificial test case
+  ["48 CFR §9903.201", "Simple Section (symbol, no space)",
+    {
+      match: "48 CFR §9903.201",
+      cfr: {
+        title: "48",
+        part: "9903",
+        section: "9903.201",
+        subsections: [],
+        id: "cfr/48/9903.201"
+      }
+    }
+  ],
+
   // http://gao.gov/products/GAO-11-166
   ["45 C.F.R. 3009.4", "Simple Section (Periods)",
     {

--- a/test/dc_code.js
+++ b/test/dc_code.js
@@ -44,6 +44,12 @@ exports["Relative patterns"] = function(test) {
       '§ 1 -1163.33',
       '1', '1163.33', [], "http://dccode.org/simple/sections/1-1163.33.html"],
 
+    // hypothetical (modified from 1-1163.20 of the DC Code)
+    [ 'section-forgiving-no-space',
+      'contribution limits for the candidate as provided under §1-1163.33.',
+      '§1-1163.33',
+      '1', '1163.33', [], "http://dccode.org/simple/sections/1-1163.33.html"],
+
     // in 16-316 of the DC Code
     [ 'section-with-word-section',
       'case shall be subject to the limitation set forth in [section 16-2326.01(b)(2)].',

--- a/test/usc.js
+++ b/test/usc.js
@@ -181,6 +181,20 @@ exports["Section symbol is ignored"] = function(test) {
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/5/552");
 
+  // https://twitter.com/CrimeADay/status/662802297588719616
+  var text = "16 U.S.C. §1375(b) & 50 C.F.R. §18.13(c) make it a federal crime to offer to buy a walrus.";
+
+  var found = Citation.find(text, {types: "usc"}).citations;
+  test.equal(found.length, 1);
+
+  var citation = found[0];
+  test.equal(citation.match, "16 U.S.C. §1375(b)");
+  test.equal(citation.citation, "16 U.S.C. 1375(b)");
+  test.equal(citation.usc.title, "16");
+  test.equal(citation.usc.section, "1375");
+  test.deepEqual(citation.usc.subsections, ["b"])
+  test.equal(citation.usc.id, "usc/16/1375/b");
+
   test.done();
 };
 

--- a/test/va_code.js
+++ b/test/va_code.js
@@ -38,7 +38,11 @@ exports["All patterns"] = function(test) {
     [ 'No Annotation or Period',
       "VA Code § 66-25.1:1",
       "66", "25.1:1", null,
-      'va-code/66/25.1:1', 'https://vacode.org/66-25.1:1/']
+      'va-code/66/25.1:1', 'https://vacode.org/66-25.1:1/'],
+    [ 'No space before section number',
+      'Va. Code Ann. §19.2-56.2 (2010)',
+      '19.2', '56.2', '2010',
+      'va-code/19.2/56.2', 'https://vacode.org/19.2-56.2/']
   ];
 
   for (var i=0; i<cases.length; i++) {


### PR DESCRIPTION
Inspired by a tweet from CrimeADay, this PR matches USC citations without a space between '§' and the section number. I rearranged the spaces in the regular expresion, and changed one `\\s+` to `\\s*`.

Re: other citations that allow section symbols:
- CFR: trailing space is already optional
- DC Code: trailing spaces appear to be mandatory, going to investigate and patch if needed
- VA Code: trailing spaces appear to be mandatory, going to investigate and patch if needed
