### PR TITLE
CFR: Allow dash/hyphen in section

### DIFF
--- a/citations/cfr.js
+++ b/citations/cfr.js
@@ -28,7 +28,7 @@ module.exports = {
         "(\\d+)\\s?" +
         "C\\.?\\s?F\\.?\\s?R\\.?" +
         "(?:[\\s,]+(?:§+|parts?))?" +
-        "\\s*((?:\\d+\\.?\\d*(?:\\s*\\((?:[a-zA-Z\\d]{1,2}|[ixvIXV]+)\\))*)+)",
+        "\\s*((?:\\d+\\.?\\d*(?:[-–—]\\d+)?(?:\\s*\\((?:[a-zA-Z\\d]{1,2}|[ixvIXV]+)\\))*)+)",
 
       fields: ['title', 'sections'],
 
@@ -38,7 +38,7 @@ module.exports = {
 
         // separate subsections for each section being considered
         var split = captures.sections.split(/[\(\)]+/).filter(function(x) {return x;});
-        section = split[0].trim();
+        section = split[0].trim().replace(/[–—]/g, '-');
         subsections = split.splice(1);
 
         if (section.indexOf(".") > 0)

--- a/test/cfr.js
+++ b/test/cfr.js
@@ -144,6 +144,34 @@ var singles = [
         id: "cfr/47/54.506"
       }
     }
+  ],
+
+  // https://twitter.com/CrimeADay/status/654462486704467968
+  ["43 U.S.C. §1733, 43 C.F.R. §8360.0–7 & 8365.2–3(f) make it a federal crime to move a table in a federal picnic area.", "Section with dash",
+    {
+      match: "43 C.F.R. §8360.0–7",
+      cfr: {
+        title: "43",
+        part: "8360",
+        section: "8360.0-7",
+        subsections: [],
+        id: "cfr/43/8360.0-7"
+      }
+    }
+  ],
+
+  // Modified from https://twitter.com/CrimeADay/status/654462486704467968
+  ["43 U.S.C. §1733, 43 C.F.R. §8360.0-7 & 8365.2-3(f) make it a federal crime to move a table in a federal picnic area.", "Section with hyphen",
+    {
+      match: "43 C.F.R. §8360.0-7",
+      cfr: {
+        title: "43",
+        part: "8360",
+        section: "8360.0-7",
+        subsections: [],
+        id: "cfr/43/8360.0-7"
+      }
+    }
   ]
 ];
 


### PR DESCRIPTION
See Title 40 Part 86, and Title 43 Part 8365, for example.

I added en-dashes and em-dashes for good measure, and normalized them all to hyphens, since that's what eCFR uses.