### PR TITLE
add a usc test for 16 USC 460nnn-101

### DIFF
--- a/test/usc.js
+++ b/test/usc.js
@@ -444,3 +444,35 @@ exports["Ranges: basic subsections"] = function(test) {
 
   test.done();
 };
+
+
+exports["Non-numeric section numbers"] = function(test) {
+  // This is the longest string that is an actual citation to a section.
+  var text = "16 USC 460nnn-101";
+
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
+  test.equal(found.length, 3);
+
+  var citation = found[0];
+  test.equal(citation.match, "16 USC 460nnn-101");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "16 U.S.C. 460nnn-101");
+  test.equal(citation.usc.title, "16");
+  test.equal(citation.usc.section, "460nnn-101");
+  test.deepEqual(citation.usc.subsections, [])
+  test.equal(citation.usc.id, "usc/16/460nnn-101");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=16&section=460nnn-101&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/16/460nnn-101");
+
+  var citation = found[1];
+  test.equal(citation.match, "16 USC 460nnn-101");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "16 U.S.C. 460nnn");
+
+  var citation = found[2];
+  test.equal(citation.match, "16 USC 460nnn-101");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "16 U.S.C. 101");
+
+  test.done();
+};


### PR DESCRIPTION
`16 USC 460nnn-101` is an actual citation, and is, by my somewhat old data, the longest citation to an actual section in the USC.

http://uscode.house.gov/view.xhtml?req=(title%3A16%20section%3A460nnn-101%20edition%3Aprelim)
http://www.gpo.gov/fdsys/pkg/USCODE-2013-title16/html/USCODE-2013-title16-chap1-subchapCXXV-partF-sec460nnn-101.htm
https://www.law.cornell.edu/uscode/text/16/460nnn-101

This PR just adds a test for the citation, so we don't lose track of a really gross one. Everything was working.