### PR TITLE
add links for the authoritative text of the USC at uscode.house.gov

### DIFF
--- a/citations/usc.js
+++ b/citations/usc.js
@@ -124,10 +124,24 @@ module.exports = {
   ],
 
   links: function(cite) {
-    // US GPO
     var title = cite.title.replace(/-app$/, '');
+    var is_appendix = cite.title.indexOf("-app") != -1;
+
     var links = {};
 
+    // House OLRC
+    links.holrc = {
+        source: {
+            name: "Office of the Law Revision Counsel of the United States House of Representatives",
+            abbreviation: "House OLRC",
+            link: "http://uscode.house.gov/",
+            authoritative: true,
+            note: "Link is to most current version of the US Code."
+        },
+        html: "http://uscode.house.gov/view.xhtml?req=(" + encodeURIComponent("title:" + (title + (is_appendix ? "a" : "")) + " section:" + cite.section + " edition:prelim") + ")"
+    };
+
+    // US GPO
     var edition;
     for (var i = 0; i < us_code_editions.length; i++) {
         if (us_code_editions[i].titles == null || us_code_editions[i].titles.indexOf(title) >= 0) {
@@ -141,7 +155,7 @@ module.exports = {
       var url = "http://api.fdsys.gov/link?collection=uscode&year="
         + edition.edition + "&title=" + title
         + "&section=" + cite.section
-        + "&type=" + (cite.title.indexOf("-app") == -1 ? "usc" : "uscappendix");
+        + "&type=" + (!is_appendix ? "usc" : "uscappendix");
       
       links.usgpo = {
           source: {
@@ -169,7 +183,7 @@ module.exports = {
             authoritative: false,
             note: "Link is to most current version of the US Code, as available at law.cornell.edu."
         },
-        landing: "https://www.law.cornell.edu/uscode/text/" + (title + (cite.title.indexOf("-app") >= 0 ? "a" : ""))
+        landing: "https://www.law.cornell.edu/uscode/text/" + (title + (is_appendix ? "a" : ""))
                           + "/" + cite.section
                           + (subsections.length ? ("#" + subsections.join("_")) : "")
     };

--- a/test/usc.js
+++ b/test/usc.js
@@ -444,3 +444,35 @@ exports["Ranges: basic subsections"] = function(test) {
 
   test.done();
 };
+
+
+exports["Non-numeric section numbers"] = function(test) {
+  // This is the longest string that is an actual citation to a section.
+  var text = "16 USC 460nnn-101";
+
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
+  test.equal(found.length, 3);
+
+  var citation = found[0];
+  test.equal(citation.match, "16 USC 460nnn-101");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "16 U.S.C. 460nnn-101");
+  test.equal(citation.usc.title, "16");
+  test.equal(citation.usc.section, "460nnn-101");
+  test.deepEqual(citation.usc.subsections, [])
+  test.equal(citation.usc.id, "usc/16/460nnn-101");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=16&section=460nnn-101&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/16/460nnn-101");
+
+  var citation = found[1];
+  test.equal(citation.match, "16 USC 460nnn-101");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "16 U.S.C. 460nnn");
+
+  var citation = found[2];
+  test.equal(citation.match, "16 USC 460nnn-101");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "16 U.S.C. 101");
+
+  test.done();
+};

--- a/test/usc.js
+++ b/test/usc.js
@@ -21,6 +21,7 @@ exports["Basic pattern"] = function(test) {
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/5/552");
+  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A5%20section%3A552%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/5/552");
 
@@ -77,6 +78,7 @@ exports["Basic subsection parsing"] = function(test) {
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, ["a", "1", "E"])
   test.equal(citation.usc.id, "usc/5/552/a/1/E");
+  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A5%20section%3A552%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/5/552#a_1_E");
 
@@ -212,6 +214,7 @@ exports["'Appendix' titles"] = function(test) {
   test.equal(citation.usc.section, "595");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/50-app/595");
+  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A50a%20section%3A595%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=50&section=595&type=uscappendix");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/50a/595");
 
@@ -232,6 +235,7 @@ exports["'note' marks"] = function(test) {
   test.equal(citation.usc.section, "612c");
   test.deepEqual(citation.usc.subsections, ["note"])
   test.equal(citation.usc.id, "usc/7/612c/note");
+  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A7%20section%3A612c%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=7&section=612c&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/7/612c#note"); // incorrect but close enough
 
@@ -253,6 +257,7 @@ exports["'et seq' marks"] = function(test) {
   test.equal(citation.usc.section, "1081");
   test.deepEqual(citation.usc.subsections, ["et-seq"])
   test.equal(citation.usc.id, "usc/29/1081/et-seq");
+  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A29%20section%3A1081%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=29&section=1081&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/29/1081");
 
@@ -461,6 +466,7 @@ exports["Non-numeric section numbers"] = function(test) {
   test.equal(citation.usc.section, "460nnn-101");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/16/460nnn-101");
+  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A16%20section%3A460nnn-101%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=16&section=460nnn-101&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/16/460nnn-101");
 


### PR DESCRIPTION
This PR is on top of #118. 

This adds links for the US Code at uscode.house.gov, and tests. This is the only authoritative source that is always up to date. These links are tied to the "prelim" version of the US Code, which is the latest as new laws are codified. (The GPO links only link to the most recent edition, which may be several years out of date.)

I'm seeing now that the permalink stuff is getting a little out of hand....