### PR TITLE
some more links fixes

### DIFF
--- a/citations/reporter.js
+++ b/citations/reporter.js
@@ -28,6 +28,18 @@ module.exports = {
   ],
 
   links: function(cite) {
+    // Create a link to the Court Listener search page for the citation. Citations
+    // can be ambiguous, and so there is no permalink to a case available without
+    // querying an API.
+    //
+    // The citation is wrapped in quotes in the query to force the CL API to do
+    // a phrase search (per Solr). Without quotes, a citation search on "410 U.S. 113"
+    // brings back `410 U.S. 257, 93 S. Ct. 880, 35 L. Ed. 2d 247, 1973 U.S. LEXIS 113`
+    // and `507 U.S. 410, 113 S. Ct. 1505, 123 L. Ed. 2d 99, 1993 U.S. LEXIS 2401`.
+    // (They match because "410" "US" and "113" appear somewhere in the whole string.)
+    // See https://github.com/freelawproject/courtlistener/issues/381, but that's only
+    // a partial fix because quotes are still needed to ensure the terms appear in
+    // the right order.
     return {
       courtlistener: {
         source: {
@@ -37,7 +49,7 @@ module.exports = {
             authoritative: false
         },
 
-        landing: "https://www.courtlistener.com/?citation=" + encodeURIComponent(module.exports.canonical(cite))
+        landing: "https://www.courtlistener.com/?citation=" + encodeURIComponent("\"" + module.exports.canonical(cite) + "\"")
       }
     };
   }

--- a/citations/usc.js
+++ b/citations/usc.js
@@ -130,7 +130,7 @@ module.exports = {
     var links = {};
 
     // House OLRC
-    links.holrc = {
+    links.house = {
         source: {
             name: "Office of the Law Revision Counsel of the United States House of Representatives",
             abbreviation: "House OLRC",

--- a/test/usc.js
+++ b/test/usc.js
@@ -21,7 +21,7 @@ exports["Basic pattern"] = function(test) {
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/5/552");
-  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A5%20section%3A552%20edition%3Aprelim)");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A5%20section%3A552%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/5/552");
 
@@ -78,7 +78,7 @@ exports["Basic subsection parsing"] = function(test) {
   test.equal(citation.usc.section, "552");
   test.deepEqual(citation.usc.subsections, ["a", "1", "E"])
   test.equal(citation.usc.id, "usc/5/552/a/1/E");
-  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A5%20section%3A552%20edition%3Aprelim)");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A5%20section%3A552%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=5&section=552&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/5/552#a_1_E");
 
@@ -214,7 +214,7 @@ exports["'Appendix' titles"] = function(test) {
   test.equal(citation.usc.section, "595");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/50-app/595");
-  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A50a%20section%3A595%20edition%3Aprelim)");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A50a%20section%3A595%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=50&section=595&type=uscappendix");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/50a/595");
 
@@ -235,7 +235,7 @@ exports["'note' marks"] = function(test) {
   test.equal(citation.usc.section, "612c");
   test.deepEqual(citation.usc.subsections, ["note"])
   test.equal(citation.usc.id, "usc/7/612c/note");
-  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A7%20section%3A612c%20edition%3Aprelim)");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A7%20section%3A612c%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2014&title=7&section=612c&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/7/612c#note"); // incorrect but close enough
 
@@ -257,7 +257,7 @@ exports["'et seq' marks"] = function(test) {
   test.equal(citation.usc.section, "1081");
   test.deepEqual(citation.usc.subsections, ["et-seq"])
   test.equal(citation.usc.id, "usc/29/1081/et-seq");
-  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A29%20section%3A1081%20edition%3Aprelim)");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A29%20section%3A1081%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=29&section=1081&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/29/1081");
 
@@ -466,7 +466,7 @@ exports["Non-numeric section numbers"] = function(test) {
   test.equal(citation.usc.section, "460nnn-101");
   test.deepEqual(citation.usc.subsections, [])
   test.equal(citation.usc.id, "usc/16/460nnn-101");
-  test.equal(citation.usc.links.holrc.html, "http://uscode.house.gov/view.xhtml?req=(title%3A16%20section%3A460nnn-101%20edition%3Aprelim)");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A16%20section%3A460nnn-101%20edition%3Aprelim)");
   test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=16&section=460nnn-101&type=usc");
   test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/16/460nnn-101");
 


### PR DESCRIPTION
1) Renamed holrc => house, per @konklone's suggestion in #119

2) In CourtListener links, wrap the citation in quotes. Without quotes, a citation search on "410 U.S. 113" brings back:

    410 U.S. 257, 93 S. Ct. 880, 35 L. Ed. 2d 247, 1973 U.S. LEXIS 113
    (410 U.S. .... LEXIS 113)

and

    507 U.S. 410, 113 S. Ct. 1505, 123 L. Ed. 2d 99, 1993 U.S. LEXIS 2401`
    (U.S. 410, 113)

This would be partially fixed by freelawproject/courtlistener#381, which would exclude matching if the citation crosses citations. That's the case in both of these examples. But the quotes also ensure the terms also occur in the right order, which might be a problem in other examples.