### PR TITLE
U.S.C.: Handle em-dashes and en-dashes

### DIFF
--- a/citations/usc.js
+++ b/citations/usc.js
@@ -51,7 +51,7 @@ module.exports = {
         "U\\.?\\s?S\\.?\\s?C\\.?" +
         "(?:\\s+(App)\.?)?\\s+" + // appendix
         "(?:(§+)\\s*)?" + // symbol
-        "((?:\\-*\\d+[\\w\\d\\-]*(?:\\([^\\)]+\\))*)+)" + // sections
+        "((?:[-–—]*\\d+[\\w\\d\\-–—]*(?:\\([^\\)]+\\))*)+)" + // sections
         "(?:\\s+(note|et\\s+seq))?", // note
 
       fields: [
@@ -64,7 +64,8 @@ module.exports = {
         var title = match.title;
         if (match.appendix) title += "-app";
 
-        var sections = match.sections.split(/-+/);
+        var sections = match.sections.split(/[-–—]+/);
+        var match_sections_normalized = match.sections.replace(/[–—]/g, '-');
 
         var range = false;
 
@@ -74,8 +75,8 @@ module.exports = {
 
         // paren before dash is unambiguous
         else {
-          var dash = match.sections.indexOf("-");
-          var paren = match.sections.indexOf("(");
+          var dash = match_sections_normalized.indexOf("-");
+          var paren = match_sections_normalized.indexOf("(");
           if (dash > 0 && paren > 0 && paren < dash)
             range = true;
         }
@@ -83,7 +84,7 @@ module.exports = {
         // if there's a hyphen and the range is ambiguous,
         // also return the original section string as one
         if ((sections.length > 1) && !range)
-          sections.unshift(match.sections);
+          sections.unshift(match_sections_normalized);
 
         return sections.map(function(section) {
           // separate subsections for each section being considered
@@ -108,7 +109,7 @@ module.exports = {
     // "section 404o-1(a) of title 50"
     {
       regex:
-        "section (\\d+[\\w\\d\-]*)((?:\\([^\\)]+\\))*)" +
+        "section (\\d+[\\w\\d\\-–—]*)((?:\\([^\\)]+\\))*)" +
         "(?:\\s+of|\\,) title (\\d+)",
 
       fields: ['section', 'subsections', 'title'],
@@ -116,7 +117,7 @@ module.exports = {
       processor: function(match) {
         return {
           title: match.title,
-          section: match.section,
+          section: match.section.replace(/[–—]/g, '-'),
           subsections: match.subsections.split(/[\(\)]+/).filter(function(x) {return x})
         };
       }

--- a/test/usc.js
+++ b/test/usc.js
@@ -484,6 +484,7 @@ exports["Non-numeric section numbers"] = function(test) {
 };
 
 exports["En-dash in section number"] = function(test) {
+  // https://github.com/unitedstates/citation/issues/123
   var text = "42 U.S.C. 288–1(a)";
 
   var found = Citation.find(text, {types: "usc", links: true}).citations;

--- a/test/usc.js
+++ b/test/usc.js
@@ -482,3 +482,34 @@ exports["Non-numeric section numbers"] = function(test) {
 
   test.done();
 };
+
+exports["En-dash in section number"] = function(test) {
+  var text = "42 U.S.C. 288–1(a)";
+
+  var found = Citation.find(text, {types: "usc", links: true}).citations;
+  test.equal(found.length, 3);
+
+  var citation = found[0];
+  test.equal(citation.match, "42 U.S.C. 288–1(a)");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "42 U.S.C. 288-1(a)");
+  test.equal(citation.usc.title, "42");
+  test.equal(citation.usc.section, "288-1");
+  test.deepEqual(citation.usc.subsections, ["a"])
+  test.equal(citation.usc.id, "usc/42/288-1/a");
+  test.equal(citation.usc.links.house.html, "http://uscode.house.gov/view.xhtml?req=(title%3A42%20section%3A288-1%20edition%3Aprelim)");
+  test.equal(citation.usc.links.usgpo.pdf, "http://api.fdsys.gov/link?collection=uscode&year=2013&title=42&section=288-1&type=usc");
+  test.equal(citation.usc.links.cornell_lii.landing, "https://www.law.cornell.edu/uscode/text/42/288-1#a");
+
+  var citation = found[1];
+  test.equal(citation.match, "42 U.S.C. 288–1(a)");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "42 U.S.C. 288");
+
+  var citation = found[2];
+  test.equal(citation.match, "42 U.S.C. 288–1(a)");
+  test.equal(citation.index, 0);
+  test.equal(citation.citation, "42 U.S.C. 1(a)");
+
+  test.done();
+};


### PR DESCRIPTION
This fixes #123 and fixes #43. I took the position that em-dashes and en-dashes are equivalent in meaning to hyphens, (in practice) and I thus normalize inside the citator to handle that. Test included.