### PR TITLE
Dependency breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "errorhandler": "*",
 
     "minimist": "*",
-    "parse5": "*",
+    "parse5": "^1.5.0",
     "xmldom": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Breaking changes in parse5 broke the build, this pins it to major version 1 for now.