### PR TITLE
Use SPDX identifier for Creative Commons Zero v1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Eric Mill <eric@konklone.com",
   "description": "Legal citation extractor. Standalone library, and optional HTTP API.",
   "version": "0.9.0",
-  "license": "cc0",
+  "license": "CC0-1.0",
   "keywords": [
     "congress",
     "laws",


### PR DESCRIPTION
This will fix a warning during `npm install`.