### PR TITLE
Addressing Issue 100 and some

### DIFF
--- a/citations/reporter.js
+++ b/citations/reporter.js
@@ -13,9 +13,9 @@ module.exports = {
   patterns: [
     {
       regex:
-        "(\\d{1,3})\\s" +
-        "(\\w+(?:\\.\\w+(?:\\.)?)?(?:\\.\\dd)?|U\\.?\\s?S\\.?|F\\. Supp\\.(?:\\s\\dd)?)\\s" +
-        "(\\d{1,4})",
+        "\\b(\\d{1,3})\\s" +
+        "([AFSNU]\\.\\s?[\\w\\.]+)\\s" +
+        "(\\d{1,4})\\b",
       fields: ['volume',  'reporter', 'page'],
       processor: function(match) {
         return {

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -59,7 +59,9 @@ exports["Absolute patterns"] = function(test) {
 
 
   ];
-
+  //----------------------
+  // Positive Test Cases
+  //----------------------
   for (var i=0; i<cases.length; i++) {
     var details = cases[i];
     var text = details[1];
@@ -79,6 +81,26 @@ exports["Absolute patterns"] = function(test) {
       test.deepEqual(citation.reporter.page, details[5]);
     } else
       console.log("No match found in: " + text);
+  }
+
+  var negativeCases = [
+      'See supra, at 666 and nn. 17 and 26, supra.', // The regex matched '17 and 26' previously; It should not match and.
+      'See supra, at 666 and nn. 1234 F. Supp. 26, supra' // If the first number is greater than 3 digits, it will pull off the last three digits. It should not.
+  ];
+
+  //----------------------
+  // Negative Test Cases
+  //----------------------
+
+  for (var i=0; i< negativeCases.length; i++) {
+    var text = negativeCases[i];
+
+    var found = Citation.find(text, {
+        types: ["reporter"],
+        context: {}
+    }).citations;
+
+    test.equal(found.length, 0);
   }
 
   test.done();


### PR DESCRIPTION
This commit addresses two classes of false positives. The first relates to
the capturing of the word 'and'. The second was that in cases like '2111
Word 111` a properly formatted string would be extracted incorrectly
ignoring the 2.